### PR TITLE
Incorrect lower bound on std. deviation parameter

### DIFF
--- a/inst/extdata/rasch_simple.stan
+++ b/inst/extdata/rasch_simple.stan
@@ -9,7 +9,7 @@ data {
 parameters {
   vector[I] beta;
   vector[J] theta;
-  real<lower=1> sigma;
+  real<lower=0> sigma;
 }
 model {
   beta ~ normal(0, 3);


### PR DESCRIPTION
Looks like a typo in the example model, however please forgive me if I am missing some context and there is a better explanation.