### PR TITLE
Update Stan syntax in all models

### DIFF
--- a/inst/extdata/2pl_latent_reg.stan
+++ b/inst/extdata/2pl_latent_reg.stan
@@ -6,19 +6,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -26,43 +30,46 @@ functions {
   }
 }
 data {
-  int<lower=1> I;               // # questions
-  int<lower=1> J;               // # persons
-  int<lower=1> N;               // # observations
-  int<lower=1, upper=I> ii[N];  // question for n
-  int<lower=1, upper=J> jj[N];  // person for n
-  int<lower=0, upper=1> y[N];   // correctness for n
-  int<lower=1> K;               // # person covariates
-  matrix[J,K] W;                // person covariate matrix
+  int<lower=1> I; // # questions
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # observations
+  array[N] int<lower=1, upper=I> ii; // question for n
+  array[N] int<lower=1, upper=J> jj; // person for n
+  array[N] int<lower=0, upper=1> y; // correctness for n
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
   vector<lower=0>[I] alpha;
-  vector[I-1] beta_free;
+  vector[I - 1] beta_free;
   vector[J] theta;
   vector[K] lambda_adj;
 }
 transformed parameters {
   vector[I] beta;
-  beta[1:(I-1)] = beta_free;
-  beta[I] = -1*sum(beta_free);
+  beta[1 : I - 1] = beta_free;
+  beta[I] = -1 * sum(beta_free);
 }
 model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
   lambda_adj ~ student_t(3, 0, 1);
-  theta ~ normal(W_adj*lambda_adj, 1);
-  y ~ bernoulli_logit(alpha[ii].*theta[jj] - beta[ii]);
+  theta ~ normal(W_adj * lambda_adj, 1);
+  y ~ bernoulli_logit(alpha[ii] .* theta[jj] - beta[ii]);
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }
-

--- a/inst/extdata/gpcm_latent_reg.stan
+++ b/inst/extdata/gpcm_latent_reg.stan
@@ -13,19 +13,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -33,52 +37,61 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y = 0, 1 ... m_i
-  int<lower=1> K;                // # person covariates
-  matrix[J,K] W;                 // person covariate matrix
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y = 0, 1 ... m_i
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  int m[I];                      // # parameters per item
-  int pos[I];                    // first position in beta vector for item
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  array[I] int m; // # parameters per item
+  array[I] int pos; // first position in beta vector for item
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   m = rep_array(0, I);
-  for(n in 1:N)
-    if(y[n] > m[ii[n]]) m[ii[n]] = y[n];
+  for (n in 1 : N) {
+    if (y[n] > m[ii[n]]) {
+      m[ii[n]] = y[n];
+    }
+  }
   pos[1] = 1;
-  for(i in 2:(I))
-    pos[i] = m[i-1] + pos[i-1];
+  for (i in 2 : I) {
+    pos[i] = m[i - 1] + pos[i - 1];
+  }
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
   vector<lower=0>[I] alpha;
-  vector[sum(m)-1] beta_free;
+  vector[sum(m) - 1] beta_free;
   vector[J] theta;
   vector[K] lambda_adj;
 }
 transformed parameters {
   vector[sum(m)] beta;
-  beta[1:(sum(m)-1)] = beta_free;
-  beta[sum(m)] = -1*sum(beta_free);
+  beta[1 : sum(m) - 1] = beta_free;
+  beta[sum(m)] = -1 * sum(beta_free);
 }
 model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
-  theta ~ normal(W_adj*lambda_adj, 1);
+  theta ~ normal(W_adj * lambda_adj, 1);
   lambda_adj ~ student_t(3, 0, 1);
-  for (n in 1:N)
-    target += pcm(y[n], theta[jj[n]].*alpha[ii[n]],
+  for (n in 1 : N) {
+    target += pcm(y[n], theta[jj[n]] .* alpha[ii[n]],
                   segment(beta, pos[ii[n]], m[ii[n]]));
+  }
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }

--- a/inst/extdata/grsm_latent_reg.stan
+++ b/inst/extdata/grsm_latent_reg.stan
@@ -13,19 +13,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -33,48 +37,53 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y in {0 ... m_i}
-  int<lower=1> K;                // # person covariates
-  matrix[J,K] W;                 // person covariate matrix
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y in {0 ... m_i}
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  int m;                         // # steps
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  int m; // # steps
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   m = max(y);
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
   vector<lower=0>[I] alpha;
-  vector[I-1] beta_free;
-  vector[m-1] kappa_free;
+  vector[I - 1] beta_free;
+  vector[m - 1] kappa_free;
   vector[J] theta;
   vector[K] lambda_adj;
 }
 transformed parameters {
   vector[I] beta;
   vector[m] kappa;
-  beta = append_row(beta_free, rep_vector(-1*sum(beta_free), 1));
-  kappa = append_row(kappa_free, rep_vector(-1*sum(kappa_free), 1));
+  beta = append_row(beta_free, rep_vector(-1 * sum(beta_free), 1));
+  kappa = append_row(kappa_free, rep_vector(-1 * sum(kappa_free), 1));
 }
 model {
   alpha ~ lognormal(1, 1);
   target += normal_lpdf(beta | 0, 3);
   target += normal_lpdf(kappa | 0, 3);
-  theta ~ normal(W_adj*lambda_adj, 1);
+  theta ~ normal(W_adj * lambda_adj, 1);
   lambda_adj ~ student_t(3, 0, 1);
-  for (n in 1:N)
+  for (n in 1 : N) {
     target += rsm(y[n], theta[jj[n]] .* alpha[ii[n]], beta[ii[n]], kappa);
+  }
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }

--- a/inst/extdata/pcm_latent_reg.stan
+++ b/inst/extdata/pcm_latent_reg.stan
@@ -13,19 +13,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -33,51 +37,60 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y = 0, 1 ... m_i
-  int<lower=1> K;                // # person covariates
-  matrix[J,K] W;                 // person covariate matrix
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y = 0, 1 ... m_i
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  int m[I];                      // # parameters per item
-  int pos[I];                    // first position in beta vector for item
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  array[I] int m; // # parameters per item
+  array[I] int pos; // first position in beta vector for item
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   m = rep_array(0, I);
-  for(n in 1:N)
-    if(y[n] > m[ii[n]]) m[ii[n]] = y[n];
+  for (n in 1 : N) {
+    if (y[n] > m[ii[n]]) {
+      m[ii[n]] = y[n];
+    }
+  }
   pos[1] = 1;
-  for(i in 2:(I))
-    pos[i] = m[i-1] + pos[i-1];
+  for (i in 2 : I) {
+    pos[i] = m[i - 1] + pos[i - 1];
+  }
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
-  vector[sum(m)-1] beta_free;
+  vector[sum(m) - 1] beta_free;
   vector[J] theta;
   real<lower=0> sigma;
   vector[K] lambda_adj;
 }
 transformed parameters {
   vector[sum(m)] beta;
-  beta[1:(sum(m)-1)] = beta_free;
-  beta[sum(m)] = -1*sum(beta_free);
+  beta[1 : sum(m) - 1] = beta_free;
+  beta[sum(m)] = -1 * sum(beta_free);
 }
 model {
   target += normal_lpdf(beta | 0, 3);
-  theta ~ normal(W_adj*lambda_adj, sigma);
+  theta ~ normal(W_adj * lambda_adj, sigma);
   lambda_adj ~ student_t(3, 0, 1);
   sigma ~ exponential(.1);
-  for (n in 1:N)
-    target += pcm(y[n], theta[jj[n]],  segment(beta, pos[ii[n]], m[ii[n]]));
+  for (n in 1 : N) {
+    target += pcm(y[n], theta[jj[n]], segment(beta, pos[ii[n]], m[ii[n]]));
+  }
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }

--- a/inst/extdata/pcm_simple.stan
+++ b/inst/extdata/pcm_simple.stan
@@ -8,27 +8,29 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y = 0, 1 ... m_i
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y = 0, 1 ... m_i
 }
 transformed data {
-  int m;                         // # parameters per item (same for all items)
+  int m; // # parameters per item (same for all items)
   m = max(y);
 }
 parameters {
-  vector[m] beta[I];
+  array[I] vector[m] beta;
   vector[J] theta;
   real<lower=0> sigma;
 }
 model {
-  for(i in 1:I)
+  for (i in 1 : I) {
     beta[i] ~ normal(0, 3);
+  }
   theta ~ normal(0, sigma);
   sigma ~ exponential(.1);
-  for (n in 1:N)
+  for (n in 1 : N) {
     target += pcm(y[n], theta[jj[n]], beta[ii[n]]);
+  }
 }

--- a/inst/extdata/rasch_latent_reg.stan
+++ b/inst/extdata/rasch_latent_reg.stan
@@ -6,19 +6,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -26,42 +30,46 @@ functions {
   }
 }
 data {
-  int<lower=1> I;               // # questions
-  int<lower=1> J;               // # persons
-  int<lower=1> N;               // # observations
-  int<lower=1, upper=I> ii[N];  // question for n
-  int<lower=1, upper=J> jj[N];  // person for n
-  int<lower=0, upper=1> y[N];   // correctness for n
-  int<lower=1> K;               // # person covariates
-  matrix[J,K] W;                // person covariate matrix
+  int<lower=1> I; // # questions
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # observations
+  array[N] int<lower=1, upper=I> ii; // question for n
+  array[N] int<lower=1, upper=J> jj; // person for n
+  array[N] int<lower=0, upper=1> y; // correctness for n
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
-  vector[I-1] beta_free;
+  vector[I - 1] beta_free;
   vector[J] theta;
   real<lower=0> sigma;
   vector[K] lambda_adj;
 }
 transformed parameters {
   vector[I] beta;
-  beta[1:(I-1)] = beta_free;
-  beta[I] = -1*sum(beta_free);
+  beta[1 : I - 1] = beta_free;
+  beta[I] = -1 * sum(beta_free);
 }
 model {
   target += normal_lpdf(beta | 0, 3);
-  theta ~ normal(W_adj*lambda_adj, sigma);
+  theta ~ normal(W_adj * lambda_adj, sigma);
   lambda_adj ~ student_t(3, 0, 1);
   sigma ~ exponential(.1);
   y ~ bernoulli_logit(theta[jj] - beta[ii]);
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }

--- a/inst/extdata/rasch_simple.stan
+++ b/inst/extdata/rasch_simple.stan
@@ -1,10 +1,10 @@
 data {
-  int<lower=1> I;               // # questions
-  int<lower=1> J;               // # persons
-  int<lower=1> N;               // # observations
-  int<lower=1, upper=I> ii[N];  // question for n
-  int<lower=1, upper=J> jj[N];  // person for n
-  int<lower=0, upper=1> y[N];   // correctness for n
+  int<lower=1> I; // # questions
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # observations
+  array[N] int<lower=1, upper=I> ii; // question for n
+  array[N] int<lower=1, upper=J> jj; // person for n
+  array[N] int<lower=0, upper=1> y; // correctness for n
 }
 parameters {
   vector[I] beta;

--- a/inst/extdata/rsm_latent_reg.stan
+++ b/inst/extdata/rsm_latent_reg.stan
@@ -13,19 +13,23 @@ functions {
     matrix[2, cols(W)] adj;
     adj[1, 1] = 0;
     adj[2, 1] = 1;
-    if(cols(W) > 1) {
-      for(k in 2:cols(W)) {                       // remaining columns
-        min_w = min(W[1:rows(W), k]);
-        max_w = max(W[1:rows(W), k]);
+    if (cols(W) > 1) {
+      for (k in 2 : cols(W)) {
+        // remaining columns
+        min_w = min(W[1 : rows(W), k]);
+        max_w = max(W[1 : rows(W), k]);
         minmax_count = 0;
-        for(j in 1:rows(W))
-          minmax_count = minmax_count + W[j,k] == min_w || W[j,k] == max_w;
-        if(minmax_count == rows(W)) {       // if column takes only 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = (max_w - min_w);
-        } else {                            // if column takes > 2 values
-          adj[1, k] = mean(W[1:rows(W), k]);
-          adj[2, k] = sd(W[1:rows(W), k]) * 2;
+        for (j in 1 : rows(W)) {
+          minmax_count = minmax_count + W[j, k] == min_w || W[j, k] == max_w;
+        }
+        if (minmax_count == rows(W)) {
+          // if column takes only 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = max_w - min_w;
+        } else {
+          // if column takes > 2 values
+          adj[1, k] = mean(W[1 : rows(W), k]);
+          adj[2, k] = sd(W[1 : rows(W), k]) * 2;
         }
       }
     }
@@ -33,27 +37,30 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y in {0 ... m_i}
-  int<lower=1> K;                // # person covariates
-  matrix[J,K] W;                 // person covariate matrix
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y in {0 ... m_i}
+  int<lower=1> K; // # person covariates
+  matrix[J, K] W; // person covariate matrix
 }
 transformed data {
-  int m;                         // # steps
-  matrix[2,K] adj;               // values for centering and scaling covariates
-  matrix[J,K] W_adj;             // centered and scaled covariates
+  int m; // # steps
+  matrix[2, K] adj; // values for centering and scaling covariates
+  matrix[J, K] W_adj; // centered and scaled covariates
   m = max(y);
   adj = obtain_adjustments(W);
-  for(k in 1:K) for(j in 1:J)
-      W_adj[j,k] = (W[j,k] - adj[1,k]) / adj[2,k];
+  for (k in 1 : K) {
+    for (j in 1 : J) {
+      W_adj[j, k] = (W[j, k] - adj[1, k]) / adj[2, k];
+    }
+  }
 }
 parameters {
-  vector[I-1] beta_free;
-  vector[m-1] kappa_free;
+  vector[I - 1] beta_free;
+  vector[m - 1] kappa_free;
   vector[J] theta;
   real<lower=0> sigma;
   vector[K] lambda_adj;
@@ -61,22 +68,24 @@ parameters {
 transformed parameters {
   vector[I] beta;
   vector[m] kappa;
-  beta[1:(I-1)] = beta_free;
-  beta[I] = -1*sum(beta_free);
-  kappa[1:(m-1)] = kappa_free;
-  kappa[m] = -1*sum(kappa_free);
+  beta[1 : I - 1] = beta_free;
+  beta[I] = -1 * sum(beta_free);
+  kappa[1 : m - 1] = kappa_free;
+  kappa[m] = -1 * sum(kappa_free);
 }
 model {
   target += normal_lpdf(beta | 0, 3);
   target += normal_lpdf(kappa | 0, 3);
-  theta ~ normal(W_adj*lambda_adj, sigma);
+  theta ~ normal(W_adj * lambda_adj, sigma);
   lambda_adj ~ student_t(3, 0, 1);
   sigma ~ exponential(.1);
-  for (n in 1:N)
+  for (n in 1 : N) {
     target += rsm(y[n], theta[jj[n]], beta[ii[n]], kappa);
+  }
 }
 generated quantities {
   vector[K] lambda;
-  lambda[2:K] = lambda_adj[2:K] ./ to_vector(adj[2,2:K]);
-  lambda[1] = W_adj[1, 1:K]*lambda_adj[1:K] - W[1, 2:K]*lambda[2:K];
+  lambda[2 : K] = lambda_adj[2 : K] ./ to_vector(adj[2, 2 : K]);
+  lambda[1] = W_adj[1, 1 : K] * lambda_adj[1 : K]
+              - W[1, 2 : K] * lambda[2 : K];
 }

--- a/inst/extdata/rsm_simple.stan
+++ b/inst/extdata/rsm_simple.stan
@@ -8,33 +8,34 @@ functions {
   }
 }
 data {
-  int<lower=1> I;                // # items
-  int<lower=1> J;                // # persons
-  int<lower=1> N;                // # responses
-  int<lower=1,upper=I> ii[N];    // i for n
-  int<lower=1,upper=J> jj[N];    // j for n
-  int<lower=0> y[N];             // response for n; y in {0 ... m_i}
+  int<lower=1> I; // # items
+  int<lower=1> J; // # persons
+  int<lower=1> N; // # responses
+  array[N] int<lower=1, upper=I> ii; // i for n
+  array[N] int<lower=1, upper=J> jj; // j for n
+  array[N] int<lower=0> y; // response for n; y in {0 ... m_i}
 }
 transformed data {
-  int m;                         // # steps
+  int m; // # steps
   m = max(y);
 }
 parameters {
   vector[I] beta;
-  vector[m-1] kappa_free;
+  vector[m - 1] kappa_free;
   vector[J] theta;
   real<lower=0> sigma;
 }
 transformed parameters {
   vector[m] kappa;
-  kappa[1:(m-1)] = kappa_free;
-  kappa[m] = -1*sum(kappa_free);
+  kappa[1 : m - 1] = kappa_free;
+  kappa[m] = -1 * sum(kappa_free);
 }
 model {
   beta ~ normal(0, 3);
   target += normal_lpdf(kappa | 0, 3);
   theta ~ normal(0, sigma);
   sigma ~ exponential(.1);
-  for (n in 1:N)
+  for (n in 1 : N) {
     target += rsm(y[n], theta[jj[n]], beta[ii[n]], kappa);
+  }
 }


### PR DESCRIPTION
This is to allow us to[ re-build the Stan Case Studies ](https://github.com/stan-dev/stan-dev.github.io/issues/189)which use `edstan`. It also future-proofs the package for RStan 2.33 and beyond.

These updates were all done automatically using the `--print-canonical` flag to the Stan compiler.